### PR TITLE
Hotfix Number Format

### DIFF
--- a/app/Notifications/BaseTriggerNotification.php
+++ b/app/Notifications/BaseTriggerNotification.php
@@ -33,7 +33,7 @@ class BaseTriggerNotification extends BaseNotification
 		return $methods;
 	}
 
-	public function formatNumberForTrigger(NotificationTrigger $trigger, float|int $number, int $decimals = 2): float|int
+	public function formatNumberForTrigger(NotificationTrigger $trigger, float|int $number, int $decimals = 2): string
 	{
 		$language = rescue(fn() => $trigger->user()->language, 'en', false);
 


### PR DESCRIPTION
fix the return type of formatNumberForTrigger() from number (float|int) to string