### PR TITLE
VaultResource fix

### DIFF
--- a/app/Http/Resources/VaultResource.php
+++ b/app/Http/Resources/VaultResource.php
@@ -41,6 +41,9 @@ class VaultResource extends JsonResource
 		}
 		$data = [];
 		foreach ($rawData as $item) {
+			if (is_string($item)) {
+				break;
+			}
 			$amount = (float) $item['amount'];
 			$priceUsd = isset($item['activePrice']['active']['amount']) ? (float) $item['activePrice']['active']['amount'] : 1;
 			$token = $item['symbol'];


### PR DESCRIPTION
break the amounts to array method, if only a string is in the array.

e.g. for inactive vaults, the collateralAmount could be:

`["15.00000000@DFI"]`